### PR TITLE
Update README and clarify CLI scope

### DIFF
--- a/blast_at_local_computer.py
+++ b/blast_at_local_computer.py
@@ -1,0 +1,304 @@
+"""Command line interface focused on genome download preparation tasks."""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+from blast_at_local_tools import (
+    ftp_download,
+    ftp_re_download,
+    ftp_to_md5,
+    ftp_to_rsync,
+    g_unzip,
+    genome_download,
+    genome_re_download,
+    md5_check,
+    md5_download,
+    md5_re_download,
+)
+
+DEFAULT_EMAIL = "a@email.address"
+
+
+def _normalize_dir_path(path: Path, create: bool = True) -> str:
+    """Return a string path that always ends with a path separator."""
+    expanded = path.expanduser()
+    if create:
+        expanded.mkdir(parents=True, exist_ok=True)
+    elif not expanded.exists():
+        raise FileNotFoundError(f"Required directory not found: {expanded}")
+    path_str = str(expanded)
+    if not path_str.endswith(os.sep):
+        path_str += os.sep
+    return path_str
+
+
+def _read_items_from_file(path: Path) -> List[str]:
+    if not path.exists():
+        raise FileNotFoundError(f"Input file not found: {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        return [line.strip() for line in handle if line.strip()]
+
+
+def _collect_gca_ids(args: argparse.Namespace) -> Sequence[str]:
+    items: List[str] = []
+    if args.gca_list:
+        items.extend(_read_items_from_file(Path(args.gca_list)))
+    if args.gca:
+        items.extend(args.gca)
+    if not items:
+        raise ValueError("No GCA identifiers were provided")
+    return items
+
+
+def _determine_email(provided: str | None) -> str:
+    if provided:
+        return provided
+    env_email = os.environ.get("NCBI_EMAIL")
+    if env_email:
+        return env_email
+    return DEFAULT_EMAIL
+
+
+def cmd_metadata_download(args: argparse.Namespace) -> None:
+    try:
+        gca_ids = _collect_gca_ids(args)
+    except ValueError as exc:
+        raise SystemExit(str(exc))
+    download_path = _normalize_dir_path(Path(args.download_path))
+    email = _determine_email(args.email)
+    ftp_download(gca_ids, worker=args.workers, download_path=download_path, email=email)
+
+
+def cmd_metadata_retry(args: argparse.Namespace) -> None:
+    download_path = _normalize_dir_path(Path(args.download_path))
+    email = _determine_email(args.email)
+    ftp_re_download(
+        error_file=args.error_file,
+        worker=args.workers,
+        download_path=download_path,
+        email=email,
+    )
+
+
+def cmd_to_rsync(args: argparse.Namespace) -> None:
+    ftp_path = _normalize_dir_path(Path(args.ftp_path), create=False)
+    rsync_path = _normalize_dir_path(Path(args.rsync_path))
+    ftp_to_rsync(ftp_path=ftp_path, rsync_path=rsync_path, process_num=args.processes)
+
+
+def cmd_genome_download(args: argparse.Namespace) -> None:
+    genome_path = _normalize_dir_path(Path(args.genome_path))
+    rsync_path = _normalize_dir_path(Path(args.rsync_path), create=False)
+    genome_download(genome_path=genome_path, rsync_path=rsync_path, worker=args.workers)
+
+
+def cmd_genome_retry(args: argparse.Namespace) -> None:
+    genome_path = _normalize_dir_path(Path(args.genome_path), create=False)
+    rsync_path = _normalize_dir_path(Path(args.rsync_path), create=False)
+    genome_re_download(genome_path=genome_path, rsync_path=rsync_path, worker=args.workers)
+
+
+def cmd_md5_address(args: argparse.Namespace) -> None:
+    ftp_path = _normalize_dir_path(Path(args.ftp_path), create=False)
+    md5_address_path = _normalize_dir_path(Path(args.md5_address_path))
+    ftp_to_md5(
+        ftp_path=ftp_path,
+        md5_address_path=md5_address_path,
+        process_num=args.processes,
+    )
+
+
+def cmd_md5_download(args: argparse.Namespace) -> None:
+    md5_address_path = _normalize_dir_path(Path(args.md5_address_path), create=False)
+    md5_download_path = _normalize_dir_path(Path(args.md5_download_path))
+    md5_download(
+        md5_download_path=md5_download_path,
+        md5_address_path=md5_address_path,
+        worker=args.workers,
+    )
+
+
+def cmd_md5_retry(args: argparse.Namespace) -> None:
+    md5_address_path = _normalize_dir_path(Path(args.md5_address_path), create=False)
+    md5_download_path = _normalize_dir_path(Path(args.md5_download_path), create=False)
+    md5_re_download(
+        md5_download_path=md5_download_path,
+        md5_address_path=md5_address_path,
+        worker=args.workers,
+    )
+
+
+def cmd_md5_check(args: argparse.Namespace) -> None:
+    generated_path = _normalize_dir_path(Path(args.generated_path), create=False)
+    download_path = _normalize_dir_path(Path(args.download_path), create=False)
+    md5_check(
+        md5_generate_path=generated_path,
+        md5_download_path=download_path,
+        process_num=args.processes,
+        show_not_match=args.show_not_match,
+    )
+
+
+def cmd_gunzip(args: argparse.Namespace) -> None:
+    genome_path = _normalize_dir_path(Path(args.genome_path), create=False)
+    g_unzip(genome_path=genome_path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Utilities for downloading and verifying genome data from NCBI",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    metadata = subparsers.add_parser(
+        "metadata-download", help="Download assembly metadata and FTP links"
+    )
+    metadata.add_argument("--gca", nargs="*", help="One or more GCA identifiers")
+    metadata.add_argument("--gca-list", help="File containing GCA identifiers")
+    metadata.add_argument(
+        "--download-path",
+        default="Data/",
+        help="Directory used to store metadata outputs",
+    )
+    metadata.add_argument("--workers", type=int, default=2, help="Thread count")
+    metadata.add_argument("--email", help="Email address for Entrez access")
+    metadata.set_defaults(func=cmd_metadata_download)
+
+    metadata_retry = subparsers.add_parser(
+        "metadata-retry", help="Retry failed metadata downloads"
+    )
+    metadata_retry.add_argument(
+        "--error-file",
+        default="link_download_error.txt",
+        help="File containing failed metadata downloads",
+    )
+    metadata_retry.add_argument(
+        "--download-path",
+        default="Data/",
+        help="Directory used to store metadata outputs",
+    )
+    metadata_retry.add_argument("--workers", type=int, default=2, help="Thread count")
+    metadata_retry.add_argument("--email", help="Email address for Entrez access")
+    metadata_retry.set_defaults(func=cmd_metadata_retry)
+
+    rsync_parser = subparsers.add_parser(
+        "make-rsync", help="Convert FTP links to rsync addresses"
+    )
+    rsync_parser.add_argument(
+        "--ftp-path", default="Data/ftp/", help="Directory containing FTP link files"
+    )
+    rsync_parser.add_argument(
+        "--rsync-path", default="Data/rsync/", help="Directory to store rsync addresses"
+    )
+    rsync_parser.add_argument("--processes", type=int, default=1, help="Process count")
+    rsync_parser.set_defaults(func=cmd_to_rsync)
+
+    genome = subparsers.add_parser(
+        "genome-download", help="Download genomes using rsync"
+    )
+    genome.add_argument(
+        "--genome-path", default="Data/download_genome/", help="Output directory"
+    )
+    genome.add_argument(
+        "--rsync-path", default="Data/rsync/", help="Directory with rsync addresses"
+    )
+    genome.add_argument("--workers", type=int, default=45, help="Thread count")
+    genome.set_defaults(func=cmd_genome_download)
+
+    genome_retry = subparsers.add_parser(
+        "genome-retry", help="Retry failed genome downloads"
+    )
+    genome_retry.add_argument(
+        "--genome-path", default="Data/download_genome/", help="Output directory"
+    )
+    genome_retry.add_argument(
+        "--rsync-path", default="Data/rsync/", help="Directory with rsync addresses"
+    )
+    genome_retry.add_argument("--workers", type=int, default=45, help="Thread count")
+    genome_retry.set_defaults(func=cmd_genome_retry)
+
+    md5_address = subparsers.add_parser(
+        "md5-address", help="Generate rsync addresses for MD5 files"
+    )
+    md5_address.add_argument(
+        "--ftp-path", default="Data/ftp/", help="Directory containing FTP link files"
+    )
+    md5_address.add_argument(
+        "--md5-address-path",
+        default="Data/md5_address/",
+        help="Directory to store MD5 rsync addresses",
+    )
+    md5_address.add_argument("--processes", type=int, default=1, help="Process count")
+    md5_address.set_defaults(func=cmd_md5_address)
+
+    md5_dl = subparsers.add_parser("md5-download", help="Download MD5 checksum files")
+    md5_dl.add_argument(
+        "--md5-address-path",
+        default="Data/md5_address/",
+        help="Directory containing MD5 rsync addresses",
+    )
+    md5_dl.add_argument(
+        "--md5-download-path",
+        default="Data/download_md5/",
+        help="Directory to store downloaded MD5 files",
+    )
+    md5_dl.add_argument("--workers", type=int, default=45, help="Thread count")
+    md5_dl.set_defaults(func=cmd_md5_download)
+
+    md5_retry = subparsers.add_parser("md5-retry", help="Retry failed MD5 downloads")
+    md5_retry.add_argument(
+        "--md5-address-path",
+        default="Data/md5_address/",
+        help="Directory containing MD5 rsync addresses",
+    )
+    md5_retry.add_argument(
+        "--md5-download-path",
+        default="Data/download_md5/",
+        help="Directory to store downloaded MD5 files",
+    )
+    md5_retry.add_argument("--workers", type=int, default=45, help="Thread count")
+    md5_retry.set_defaults(func=cmd_md5_retry)
+
+    md5_checker = subparsers.add_parser(
+        "md5-check", help="Validate downloaded genomes using MD5 sums"
+    )
+    md5_checker.add_argument(
+        "--generated-path",
+        default="Data/generated_md5/",
+        help="Directory containing generated MD5 sums",
+    )
+    md5_checker.add_argument(
+        "--download-path",
+        default="Data/download_md5/",
+        help="Directory with downloaded MD5 sums",
+    )
+    md5_checker.add_argument("--processes", type=int, default=1, help="Process count")
+    md5_checker.add_argument(
+        "--show-not-match",
+        action="store_true",
+        help="Display unmatched genome identifiers",
+    )
+    md5_checker.set_defaults(func=cmd_md5_check)
+
+    gunzip_parser = subparsers.add_parser(
+        "gunzip", help="Decompress downloaded genome archives"
+    )
+    gunzip_parser.add_argument(
+        "--genome-path", default="Data/download_genome/", help="Directory with genomes"
+    )
+    gunzip_parser.set_defaults(func=cmd_gunzip)
+
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasker.py
+++ b/tasker.py
@@ -1,0 +1,225 @@
+"""Task execution helpers for blast_at_local_computer."""
+from __future__ import annotations
+
+import concurrent.futures
+import subprocess
+import random
+from multiprocessing import Lock, Process, Manager
+from pathlib import Path
+from time import sleep
+from typing import Any, Dict, List, Optional, Tuple
+
+__version__ = "0.1.0"
+
+
+class BASE_Tasker:
+    def __init__(self, op_path: str, V: str = __version__):
+        self.version = V
+        self.op_path = Path(op_path)
+        self.base_cmd_: List[str] = []  # 默认为空列表
+
+    def one_task_cmd_lst_modifier(
+        self, task_pack: Tuple[Any, ...], assigned_resource: int
+    ) -> List[str]:
+        """
+        修改基础命令以适配具体任务
+
+        参数:
+            task_pack: 任务参数元组
+            assigned_resource: 分配的资源数
+
+        返回:
+            修改后的命令列表
+        """
+        # 在子类中应重写此方法
+        return self.base_cmd_.copy() + list(task_pack) + [str(assigned_resource)]
+
+    def Psudo_pool_one_sub_excute(
+        self,
+        task_queue,
+        # each element is a task pack. task_pack[0] is the task string, task_pack[1] is the task size
+        resource_pool: Dict[str, int],
+        resource_lock_: Lock,
+        total_size: int,
+        available_resource: int,
+    ) -> None:
+        """动态任务调度器 - 按任务大小比例分配线程"""
+        while not task_queue.empty():
+            try:
+                # 动态获取任务
+                with resource_lock_:
+                    if task_queue.empty():
+                        return
+                    task_pack = task_queue.get_nowait()
+            except Exception:
+                return
+
+            # 计算任务大小比例
+            size_ratio = task_pack[1] / total_size
+
+            # 计算所需线程数 (至少1个)
+            thread_should_be_given = max(1, int(size_ratio * available_resource))
+
+            # 等待直到有足够资源
+            while True:
+                with resource_lock_:
+                    if resource_pool["available"] >= thread_should_be_given:
+                        if resource_pool["tasks_left"] < available_resource:
+                            thread_given = max(
+                                thread_should_be_given,
+                                resource_pool["available"] // resource_pool["tasks_left"],
+                            )
+                        else:
+                            thread_given = thread_should_be_given
+                        resource_pool["available"] -= thread_given
+                        break
+                # wait and check
+                sleep(random.randint(1, 2))
+
+            cmd = self.one_task_cmd_lst_modifier(task_pack[0], thread_given)
+            # 执行任务
+            try:
+                subprocess.run(cmd, check=True, capture_output=True, text=True)
+            except subprocess.CalledProcessError as e:
+                error_msg = (
+                    f"Error: {cmd} -->\n Err CODE:\n {e.returncode}\n{e.stderr}"
+                )
+                print(error_msg)
+
+            # 归还资源
+            with resource_lock_:
+                resource_pool["available"] += thread_given
+                resource_pool["tasks_left"] -= 1
+
+            # 标记任务完成
+            task_queue.task_done()
+
+    def Psudo_pool_excute(
+        self,
+        sorted_mission_lst: List[Tuple[str, int]],
+        total_size: int,
+        available_resource: int,
+    ) -> None:
+        with Manager() as manager:
+            # 创建任务队列
+            task_queue = manager.Queue()
+            for task_pack in sorted_mission_lst:
+                task_queue.put(task_pack)
+
+            # 创建共享资源池
+            resource_pool = manager.dict()
+            resource_pool["available"] = available_resource  # 初始可用线程数
+            resource_pool["tasks_left"] = len(sorted_mission_lst)
+            st_lock = manager.Lock()
+            # 创建进程 (进程数=min(总任务数, 进程数))
+            jobs: List[Process] = []
+            actual_procs = min(len(sorted_mission_lst), available_resource)
+
+            for _ in range(actual_procs):
+                p = Process(
+                    target=self.Psudo_pool_one_sub_excute,
+                    args=(
+                        task_queue,
+                        resource_pool,
+                        st_lock,
+                        total_size,
+                        available_resource,
+                    ),
+                )
+                jobs.append(p)
+                p.start()
+
+            # 等待所有任务完成
+            task_queue.join()
+
+            # 终止所有进程
+            for p in jobs:
+                p.join(timeout=1.0)
+                if p.is_alive():
+                    p.terminate()
+
+    def Pool_worker(
+        self,
+        task_pack: Tuple[Any, ...],  # 任务参数包
+        thread: int = 1,
+    ) -> Optional[str]:
+        """
+        进程池工作函数
+
+        参数:
+            task: 任务参数元组
+            thread: 分配的线程数
+
+        返回:
+            执行结果消息
+        """
+        cmd = self.one_task_cmd_lst_modifier(task_pack, thread)
+
+        try:
+            result = subprocess.run(
+                cmd, check=True, capture_output=True, text=True
+            )
+            return result.stdout
+        except subprocess.CalledProcessError as e:
+            error_msg = f"Error: {cmd} -->\n Err CODE:\n {e.returncode}\n{e.stderr}"
+            print(error_msg)
+            return None
+
+    def Pool_excute(
+        self, tasks: List[Tuple[Any, ...]], processes: int
+    ) -> None:
+        """
+        并行执行任务（使用标准进程池）
+
+        参数:
+            tasks: 任务列表
+            processes: 使用的进程数
+        """
+        # 使用进程池执行任务
+        with concurrent.futures.ProcessPoolExecutor(max_workers=processes) as pool:
+            futures = [pool.submit(self.Pool_worker, *task) for task in tasks]
+            for future in concurrent.futures.as_completed(futures):
+                future.result()
+
+    def excute(
+        self,
+        tasks: List[Tuple[Tuple[Any, ...], int]],
+        max_workers: Optional[int] = None,
+    ) -> None:
+        """使用线程池执行任务，适用于 I/O 密集型任务。"""
+        if not tasks:
+            return
+
+        if max_workers is None:
+            max_workers = len(tasks)
+
+        def _run(task: Tuple[Tuple[Any, ...], int]) -> Optional[str]:
+            task_pack, thread = task
+            return self.Pool_worker(task_pack, thread)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(_run, task) for task in tasks]
+            for future in concurrent.futures.as_completed(futures):
+                future.result()
+
+
+class RsyncTasker(BASE_Tasker):
+    """简单的 rsync 任务执行器"""
+
+    def __init__(self, op_path: str):
+        super().__init__(op_path)
+        self.base_cmd_ = ["rsync", "-avzq"]
+
+    def one_task_cmd_lst_modifier(
+        self, task_pack: Tuple[Any, ...], assigned_resource: int
+    ) -> List[str]:
+        if not task_pack:
+            raise ValueError("task_pack must include the rsync source address")
+
+        address = str(task_pack[0])
+        if len(task_pack) > 1:
+            destination = str(task_pack[1])
+        else:
+            destination = str(self.op_path)
+
+        return self.base_cmd_.copy() + [address, destination]


### PR DESCRIPTION
## Summary
- rewrite the README with detailed CLI download workflow instructions and dependency information
- clarify that the CLI focuses on genome acquisition steps and leave downstream BLAST work to the notebook
- align the CLI parser description and MD5 path defaults with the download-only scope

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cfbf27d4bc8329bac0dd3d054e4059