### PR TITLE
CLI-0.1: download/metadata workflow updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,30 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# macOS / Windows noise
+.DS_Store
+Thumbs.db
+
+# Editor settings
+.idea/
+.vscode/
+
+# Project runtime outputs (CLI-generated)
+link_download_error.txt
+md5_download_error.txt
+md5_generated_error.txt
+md5_not_match.txt
+metadata_enrich_error.txt
+metadata_enriched.tsv
+test_*.log
+
+# Default generated data folders from CLI workflow
+Data/ftp/
+Data/jsons/
+Data/rsync/
+Data/download_genome/
+Data/download_md5/
+Data/generated_md5/
+Data/generate_md5/
+Data/md5_address/

--- a/src/blast_at_local_computer.py
+++ b/src/blast_at_local_computer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 from pathlib import Path
 from typing import Iterable, List, Sequence
 
@@ -17,9 +18,11 @@ from blast_at_local_tools import (
     md5_check,
     md5_download,
     md5_re_download,
+    metadata_enrich,
 )
 
 DEFAULT_EMAIL = "a@email.address"
+CLI_RELEASE_LABEL = "CLI-0.1"
 
 
 def _normalize_dir_path(path: Path, create: bool = True) -> str:
@@ -62,6 +65,32 @@ def _determine_email(provided: str | None) -> str:
     return DEFAULT_EMAIL
 
 
+def _warn_high_workers(command: str, workers: int) -> None:
+    if command in {"genome-download", "md5-download"} and workers > 5:
+        print(
+            (
+                "\n"
+                "================================ WARNING ================================\n"
+                "NCBI endpoints may throttle heavy parallel traffic; we highly suggest\n"
+                "using fewer than 5 workers for stable throughput and fair usage.\n"
+                f"Current {command} workers: {workers}\n"
+                "=========================================================================\n"
+            ),
+            file=sys.stderr,
+        )
+    if command == "gunzip" and workers > 15:
+        print(
+            (
+                "\n"
+                "================================ WARNING ================================\n"
+                "HDD may not be able to handle more than 15 simultaneous decompressions.\n"
+                f"Current gunzip workers: {workers}\n"
+                "=========================================================================\n"
+            ),
+            file=sys.stderr,
+        )
+
+
 def cmd_metadata_download(args: argparse.Namespace) -> None:
     try:
         gca_ids = _collect_gca_ids(args)
@@ -90,6 +119,7 @@ def cmd_to_rsync(args: argparse.Namespace) -> None:
 
 
 def cmd_genome_download(args: argparse.Namespace) -> None:
+    _warn_high_workers("genome-download", args.workers)
     genome_path = _normalize_dir_path(Path(args.genome_path))
     rsync_path = _normalize_dir_path(Path(args.rsync_path), create=False)
     genome_download(genome_path=genome_path, rsync_path=rsync_path, worker=args.workers)
@@ -112,6 +142,7 @@ def cmd_md5_address(args: argparse.Namespace) -> None:
 
 
 def cmd_md5_download(args: argparse.Namespace) -> None:
+    _warn_high_workers("md5-download", args.workers)
     md5_address_path = _normalize_dir_path(Path(args.md5_address_path), create=False)
     md5_download_path = _normalize_dir_path(Path(args.md5_download_path))
     md5_download(
@@ -134,22 +165,56 @@ def cmd_md5_retry(args: argparse.Namespace) -> None:
 def cmd_md5_check(args: argparse.Namespace) -> None:
     generated_path = _normalize_dir_path(Path(args.generated_path), create=False)
     download_path = _normalize_dir_path(Path(args.download_path), create=False)
+    output_path = (
+        Path(args.not_match_output).expanduser()
+        if args.not_match_output
+        else Path.cwd() / "md5_not_match.txt"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     md5_check(
         md5_generate_path=generated_path,
         md5_download_path=download_path,
         process_num=args.processes,
-        show_not_match=args.show_not_match,
+        not_match_output=str(output_path),
     )
 
 
 def cmd_gunzip(args: argparse.Namespace) -> None:
+    _warn_high_workers("gunzip", args.workers)
     genome_path = _normalize_dir_path(Path(args.genome_path), create=False)
-    g_unzip(genome_path=genome_path)
+    g_unzip(genome_path=genome_path, worker=args.workers)
+
+
+def cmd_metadata_enrich(args: argparse.Namespace) -> None:
+    json_path = _normalize_dir_path(Path(args.json_path), create=False)
+    output_tsv = (
+        Path(args.output_tsv).expanduser()
+        if args.output_tsv
+        else Path.cwd() / "metadata_enriched.tsv"
+    )
+    error_file = (
+        Path(args.error_file).expanduser()
+        if args.error_file
+        else Path.cwd() / "metadata_enrich_error.txt"
+    )
+    output_tsv.parent.mkdir(parents=True, exist_ok=True)
+    error_file.parent.mkdir(parents=True, exist_ok=True)
+    email = _determine_email(args.email)
+    metadata_enrich(
+        json_path=json_path,
+        output_tsv=str(output_tsv),
+        worker=args.workers,
+        email=email,
+        error_file=str(error_file),
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Utilities for downloading and verifying genome data from NCBI",
+        description=(
+            "Utilities for downloading and verifying genome data from NCBI "
+            f"({CLI_RELEASE_LABEL})"
+        ),
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -184,40 +249,73 @@ def build_parser() -> argparse.ArgumentParser:
     metadata_retry.add_argument("--email", help="Email address for Entrez access")
     metadata_retry.set_defaults(func=cmd_metadata_retry)
 
+    metadata_enrich_parser = subparsers.add_parser(
+        "metadata-enrich",
+        help="Enrich metadata JSON files with BioSample attributes",
+    )
+    metadata_enrich_parser.add_argument(
+        "--json-path",
+        default="Data/jsons/",
+        help="Directory containing metadata JSON files",
+    )
+    metadata_enrich_parser.add_argument(
+        "--output-tsv",
+        help="Output TSV path (default: $PWD/metadata_enriched.tsv)",
+    )
+    metadata_enrich_parser.add_argument(
+        "--workers",
+        type=int,
+        default=2,
+        help="Thread count for BioSample enrichment",
+    )
+    metadata_enrich_parser.add_argument("--email", help="Email address for Entrez access")
+    metadata_enrich_parser.add_argument(
+        "--error-file",
+        help="Error log path (default: $PWD/metadata_enrich_error.txt)",
+    )
+    metadata_enrich_parser.set_defaults(func=cmd_metadata_enrich)
+
     rsync_parser = subparsers.add_parser(
-        "make-rsync", help="Convert FTP links to rsync addresses"
+        "make-rsync", help="Convert FTP links to rsync-style address files"
     )
     rsync_parser.add_argument(
         "--ftp-path", default="Data/ftp/", help="Directory containing FTP link files"
     )
     rsync_parser.add_argument(
-        "--rsync-path", default="Data/rsync/", help="Directory to store rsync addresses"
+        "--rsync-path",
+        default="Data/rsync/",
+        help="Directory to store address files for downstream downloads",
     )
     rsync_parser.add_argument("--processes", type=int, default=1, help="Process count")
     rsync_parser.set_defaults(func=cmd_to_rsync)
 
     genome = subparsers.add_parser(
-        "genome-download", help="Download genomes using rsync"
+        "genome-download",
+        help="Download genomes (auto-converts rsync/ftp links to HTTPS)",
     )
     genome.add_argument(
         "--genome-path", default="Data/download_genome/", help="Output directory"
     )
     genome.add_argument(
-        "--rsync-path", default="Data/rsync/", help="Directory with rsync addresses"
+        "--rsync-path",
+        default="Data/rsync/",
+        help="Directory containing genome URL manifests (rsync/ftp/https)",
     )
-    genome.add_argument("--workers", type=int, default=45, help="Thread count")
+    genome.add_argument("--workers", type=int, default=2, help="Thread count")
     genome.set_defaults(func=cmd_genome_download)
 
     genome_retry = subparsers.add_parser(
-        "genome-retry", help="Retry failed genome downloads"
+        "genome-retry", help="Retry failed genome downloads from URL manifests"
     )
     genome_retry.add_argument(
         "--genome-path", default="Data/download_genome/", help="Output directory"
     )
     genome_retry.add_argument(
-        "--rsync-path", default="Data/rsync/", help="Directory with rsync addresses"
+        "--rsync-path",
+        default="Data/rsync/",
+        help="Directory containing genome URL manifests (rsync/ftp/https)",
     )
-    genome_retry.add_argument("--workers", type=int, default=45, help="Thread count")
+    genome_retry.add_argument("--workers", type=int, default=2, help="Thread count")
     genome_retry.set_defaults(func=cmd_genome_retry)
 
     md5_address = subparsers.add_parser(
@@ -229,37 +327,40 @@ def build_parser() -> argparse.ArgumentParser:
     md5_address.add_argument(
         "--md5-address-path",
         default="Data/md5_address/",
-        help="Directory to store MD5 rsync addresses",
+        help="Directory to store MD5 manifest URL files",
     )
     md5_address.add_argument("--processes", type=int, default=1, help="Process count")
     md5_address.set_defaults(func=cmd_md5_address)
 
-    md5_dl = subparsers.add_parser("md5-download", help="Download MD5 checksum files")
+    md5_dl = subparsers.add_parser(
+        "md5-download",
+        help="Download MD5 checksum files (auto-converts rsync/ftp links to HTTPS)",
+    )
     md5_dl.add_argument(
         "--md5-address-path",
         default="Data/md5_address/",
-        help="Directory containing MD5 rsync addresses",
+        help="Directory containing MD5 URL manifests (rsync/ftp/https)",
     )
     md5_dl.add_argument(
         "--md5-download-path",
         default="Data/download_md5/",
         help="Directory to store downloaded MD5 files",
     )
-    md5_dl.add_argument("--workers", type=int, default=45, help="Thread count")
+    md5_dl.add_argument("--workers", type=int, default=2, help="Thread count")
     md5_dl.set_defaults(func=cmd_md5_download)
 
     md5_retry = subparsers.add_parser("md5-retry", help="Retry failed MD5 downloads")
     md5_retry.add_argument(
         "--md5-address-path",
         default="Data/md5_address/",
-        help="Directory containing MD5 rsync addresses",
+        help="Directory containing MD5 URL manifests (rsync/ftp/https)",
     )
     md5_retry.add_argument(
         "--md5-download-path",
         default="Data/download_md5/",
         help="Directory to store downloaded MD5 files",
     )
-    md5_retry.add_argument("--workers", type=int, default=45, help="Thread count")
+    md5_retry.add_argument("--workers", type=int, default=2, help="Thread count")
     md5_retry.set_defaults(func=cmd_md5_retry)
 
     md5_checker = subparsers.add_parser(
@@ -277,9 +378,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     md5_checker.add_argument("--processes", type=int, default=1, help="Process count")
     md5_checker.add_argument(
-        "--show-not-match",
-        action="store_true",
-        help="Display unmatched genome identifiers",
+        "--not-match-output",
+        help="Mismatch output file path (default: $PWD/md5_not_match.txt)",
     )
     md5_checker.set_defaults(func=cmd_md5_check)
 
@@ -288,6 +388,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     gunzip_parser.add_argument(
         "--genome-path", default="Data/download_genome/", help="Directory with genomes"
+    )
+    gunzip_parser.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        help="Thread count for parallel decompression",
     )
     gunzip_parser.set_defaults(func=cmd_gunzip)
 

--- a/src/blast_at_local_tools/__init__.py
+++ b/src/blast_at_local_tools/__init__.py
@@ -7,7 +7,13 @@ focused submodules but the import surface remains unchanged so existing scripts
 can continue to ``import blast_at_local_tools``.
 """
 
-from .metadata import get_assembly_summary, get_assemblies, ftp_download, ftp_re_download
+from .metadata import (
+    ftp_download,
+    ftp_re_download,
+    get_assemblies,
+    get_assembly_summary,
+    metadata_enrich,
+)
 from .transfers import (
     ftp_modify,
     ftp_to_rsync,
@@ -60,6 +66,7 @@ __all__ = [
     "make_db_by_ls",
     "make_a_db",
     "make_database",
+    "metadata_enrich",
     "md5_address",
     "md5_check",
     "md5_download",

--- a/src/blast_at_local_tools/metadata.py
+++ b/src/blast_at_local_tools/metadata.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import time
 import urllib.request
-from concurrent.futures import ThreadPoolExecutor
-from typing import Iterable, Sequence
+import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Sequence
 
 import pandas as pd
 from Bio import Entrez
@@ -114,5 +117,214 @@ def ftp_re_download(
         for gca in error_df["gca"]:
             executor.submit(get_assemblies, gca, False, download_path, email)
     end_time = time.time()
+    print(f"final time usage {end_time - start_time}")
+    print(time.asctime())
+
+
+def _extract_summary_record(raw_json: Dict[str, Any], fallback_id: str) -> Dict[str, str]:
+    records = raw_json.get("DocumentSummarySet", {}).get("DocumentSummary", [])
+    if not records:
+        return {
+            "assembly_id": fallback_id,
+            "assembly_accession": fallback_id,
+            "biosample_id": "",
+            "biosample_accession": "",
+        }
+
+    summary = records[0]
+    return {
+        "assembly_id": fallback_id,
+        "assembly_accession": str(summary.get("AssemblyAccession") or fallback_id),
+        "biosample_id": str(summary.get("BioSampleId") or "").strip(),
+        "biosample_accession": str(summary.get("BioSampleAccn") or "").strip(),
+    }
+
+
+def _normalize_attr_key(raw_key: str) -> str:
+    cleaned = raw_key.strip().lower().replace("-", "_").replace(" ", "_")
+    return "_".join(part for part in cleaned.split("_") if part)
+
+
+def _extract_biosample_attributes(xml_payload: str) -> Dict[str, str]:
+    attributes: Dict[str, str] = {}
+    root = ET.fromstring(xml_payload)
+    for element in root.findall(".//Attribute"):
+        raw_key = (
+            element.attrib.get("harmonized_name")
+            or element.attrib.get("attribute_name")
+            or element.attrib.get("display_name")
+            or ""
+        )
+        raw_value = (element.text or "").strip()
+        if not raw_key or not raw_value:
+            continue
+        key = _normalize_attr_key(raw_key)
+        if key and key not in attributes:
+            attributes[key] = raw_value
+    return attributes
+
+
+def _pick_first(attributes: Dict[str, str], keys: Sequence[str]) -> str:
+    for key in keys:
+        value = attributes.get(key, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _extract_year(collection_date_raw: str) -> str:
+    match = re.search(r"(19|20)\d{2}", collection_date_raw)
+    return match.group(0) if match else ""
+
+
+def _read_json_record(json_file: Path) -> Dict[str, str]:
+    with json_file.open("r", encoding="utf-8") as handle:
+        raw = json.load(handle)
+    return _extract_summary_record(raw, fallback_id=json_file.stem)
+
+
+def _enrich_one_json(json_file: Path, email: str) -> tuple[Dict[str, str], str]:
+    record = _read_json_record(json_file)
+    base_row = {
+        "assembly_id": record["assembly_id"],
+        "assembly_accession": record["assembly_accession"],
+        "biosample_id": record["biosample_id"],
+        "biosample_accession": record["biosample_accession"],
+        "country_location": "",
+        "isolate": "",
+        "host": "",
+        "isolation_source": "",
+        "collection_date_raw": "",
+        "year": "",
+    }
+
+    biosample_id = record["biosample_id"]
+    if not biosample_id:
+        return base_row, f"{record['assembly_id']}\tmissing BioSampleId"
+
+    Entrez.email = email
+    with Entrez.efetch(db="biosample", id=biosample_id, retmode="xml") as handle:
+        xml_payload = handle.read()
+    if isinstance(xml_payload, bytes):
+        xml_payload = xml_payload.decode("utf-8", errors="replace")
+
+    attributes = _extract_biosample_attributes(xml_payload)
+    collection_date_raw = _pick_first(
+        attributes,
+        (
+            "collection_date",
+            "collectiondate",
+            "sampling_date",
+            "date_of_collection",
+        ),
+    )
+
+    base_row.update(
+        {
+            "country_location": _pick_first(
+                attributes,
+                (
+                    "geo_loc_name",
+                    "geographic_location",
+                    "geographic_location_country_and_or_sea",
+                    "country",
+                    "location",
+                ),
+            ),
+            "isolate": _pick_first(attributes, ("isolate",)),
+            "host": _pick_first(attributes, ("host", "host_name")),
+            "isolation_source": _pick_first(
+                attributes,
+                ("isolation_source", "isolation_site", "source"),
+            ),
+            "collection_date_raw": collection_date_raw,
+            "year": _extract_year(collection_date_raw),
+        }
+    )
+    return base_row, ""
+
+
+def metadata_enrich(
+    json_path: str = "Data/jsons/",
+    output_tsv: str = "metadata_enriched.tsv",
+    worker: int = 2,
+    email: str = "a@email.address",
+    error_file: str = "metadata_enrich_error.txt",
+) -> None:
+    """Fetch BioSample XML metadata and create an enriched TSV from assembly JSON files."""
+
+    json_dir = Path(json_path)
+    output_path = Path(output_tsv)
+    error_path = Path(error_file)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    error_path.parent.mkdir(parents=True, exist_ok=True)
+
+    json_files = sorted(json_dir.glob("*.json"))
+    columns = [
+        "assembly_id",
+        "assembly_accession",
+        "biosample_id",
+        "biosample_accession",
+        "country_location",
+        "isolate",
+        "host",
+        "isolation_source",
+        "collection_date_raw",
+        "year",
+    ]
+
+    if not json_files:
+        pd.DataFrame(columns=columns).to_csv(output_path, sep="\t", index=False)
+        error_path.write_text("", encoding="utf-8")
+        print(f"No metadata JSON files found in {json_dir}")
+        print(f"Created empty TSV: {output_path}")
+        print(f"Error log written to: {error_path}")
+        return
+
+    rows: List[Dict[str, str]] = []
+    errors: List[str] = []
+
+    start_time = time.time()
+    print(time.asctime())
+
+    with ThreadPoolExecutor(max_workers=max(1, worker)) as executor:
+        futures = {executor.submit(_enrich_one_json, json_file, email): json_file for json_file in json_files}
+        for future in as_completed(futures):
+            json_file = futures[future]
+            try:
+                row, error_msg = future.result()
+            except Exception as ex:  # pragma: no cover - network failures are contextual
+                row = {
+                    "assembly_id": json_file.stem,
+                    "assembly_accession": json_file.stem,
+                    "biosample_id": "",
+                    "biosample_accession": "",
+                    "country_location": "",
+                    "isolate": "",
+                    "host": "",
+                    "isolation_source": "",
+                    "collection_date_raw": "",
+                    "year": "",
+                }
+                error_msg = f"{json_file.stem}\t{type(ex).__name__}: {ex}"
+            rows.append(row)
+            if error_msg:
+                errors.append(error_msg)
+
+    data_frame = pd.DataFrame(rows, columns=columns).sort_values(
+        by=["assembly_accession", "assembly_id"],
+        kind="mergesort",
+    )
+    data_frame.to_csv(output_path, sep="\t", index=False)
+    with error_path.open("w", encoding="utf-8") as handle:
+        if errors:
+            handle.write("\n".join(errors) + "\n")
+
+    end_time = time.time()
+    print(f"Processed JSON files: {len(json_files)}")
+    print(f"Rows written: {len(data_frame)}")
+    print(f"Records with enrichment errors: {len(errors)}")
+    print(f"Enriched metadata TSV: {output_path}")
+    print(f"Error log written to: {error_path}")
     print(f"final time usage {end_time - start_time}")
     print(time.asctime())


### PR DESCRIPTION
## Summary
- update CLI defaults/warnings and command help for the CLI-0.1 workflow
- improve transfer logic for genome and md5 operations
- add metadata enrichment updates and exports
- refresh README and ignore patterns to match current workflow

## Scope
- 7 files changed
- no notebook edits